### PR TITLE
Added listId and instanceId to ListChangeEventHandler (plus 2 other fixes)

### DIFF
--- a/Examples/TouchPortalApi.Console/Program.cs
+++ b/Examples/TouchPortalApi.Console/Program.cs
@@ -28,7 +28,7 @@ namespace TouchPortalApi.ConsoleApp {
       };
 
       // On List Change Event
-      messageProcessor.OnListChangeEventHandler += (actionId, value) => {
+      messageProcessor.OnListChangeEventHandler += (actionId, listId, instanceId, value) => {
       };
 
       // On Plugin Disconnect

--- a/Examples/TouchPortalApi.Service/Worker.cs
+++ b/Examples/TouchPortalApi.Service/Worker.cs
@@ -32,7 +32,7 @@ namespace TouchPortalApi.Service {
       };
 
       // On List Change Event
-      _messageProcessor.OnListChangeEventHandler += (actionId, value) => {
+      _messageProcessor.OnListChangeEventHandler += (actionId, listId, instanceId, value) => {
         _logger.LogInformation($"{DateTime.Now} Choice Event Fired.");
       };
 

--- a/Examples/TouchPortalApi.WebApp/Startup.cs
+++ b/Examples/TouchPortalApi.WebApp/Startup.cs
@@ -46,7 +46,7 @@ namespace TouchPortalApi.WebApp {
       };
 
       // On List Change Event
-      messageProcessor.OnListChangeEventHandler += (actionId, value) => {
+      messageProcessor.OnListChangeEventHandler += (actionId, listId, instanceId, value) => {
       };
 
       // On Plugin Disconnect

--- a/TouchPortalApi/Interfaces/IMessageProcessor.cs
+++ b/TouchPortalApi/Interfaces/IMessageProcessor.cs
@@ -4,7 +4,7 @@ using TouchPortalApi.Models;
 
 namespace TouchPortalApi.Interfaces {
   public delegate void ActionEventHandler(string actionId, List<ActionData> dataList);
-  public delegate void ListChangeEventHandler(string actionId, string value);
+  public delegate void ListChangeEventHandler(string actionId, string listId, string instanceId, string value);
   public delegate void CloseEventHandler();
   public delegate void ConnectEventHandler();
 

--- a/TouchPortalApi/MessageProcessor.cs
+++ b/TouchPortalApi/MessageProcessor.cs
@@ -34,7 +34,7 @@ namespace TouchPortalApi {
     /// <summary>
     /// If the TP Client is paired already or not.
     /// </summary>
-    public bool IsPaired { get; set; };
+    public bool IsPaired { get; set; }
 
     /// <summary>
     /// Constructor

--- a/TouchPortalApi/MessageProcessor.cs
+++ b/TouchPortalApi/MessageProcessor.cs
@@ -137,7 +137,7 @@ namespace TouchPortalApi {
     /// </summary>
     /// <param name="change">The list change event</param>
     private void HandleListChangeEvent(TPListChange change) {
-      OnListChangeEventHandler?.Invoke(change.ActionId, change.Value);
+      OnListChangeEventHandler?.Invoke(change.ActionId, change.ListId, change.InstanceId, change.Value);
     }
 
     /// <summary>

--- a/TouchPortalApi/Models/ChoiceUpdate.cs
+++ b/TouchPortalApi/Models/ChoiceUpdate.cs
@@ -1,13 +1,19 @@
 ﻿using Newtonsoft.Json;
 using System.ComponentModel;
 
-namespace TouchPortalApi.Models {
-  public class ChoiceUpdate {
-    public static readonly string Type = "choiceUpdate";
-    public string Id { get; set; }
-    [DefaultValue("")]
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore)]
-    public string InstanceId { get; set; }
-    public string[] Value { get; set; }
-  }
+namespace TouchPortalApi.Models
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class ChoiceUpdate
+    {
+        [JsonProperty]
+        public static readonly string Type = "choiceUpdate";
+        [JsonProperty]
+        public string Id { get; set; }
+        [DefaultValue("")]
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string InstanceId { get; set; }
+        [JsonProperty]
+        public string[] Value { get; set; }
+    }
 }

--- a/TouchPortalApi/Models/ChoiceUpdate.cs
+++ b/TouchPortalApi/Models/ChoiceUpdate.cs
@@ -3,17 +3,14 @@ using System.ComponentModel;
 
 namespace TouchPortalApi.Models
 {
-    [JsonObject(MemberSerialization.OptIn)]
     public class ChoiceUpdate
     {
         [JsonProperty]
         public static readonly string Type = "choiceUpdate";
-        [JsonProperty]
         public string Id { get; set; }
         [DefaultValue("")]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string InstanceId { get; set; }
-        [JsonProperty]
         public string[] Value { get; set; }
     }
 }

--- a/TouchPortalApi/Models/StateCreate.cs
+++ b/TouchPortalApi/Models/StateCreate.cs
@@ -2,16 +2,12 @@
 
 namespace TouchPortalApi.Models
 {
-    [JsonObject(MemberSerialization.OptIn)]
     public class StateCreate
     {
         [JsonProperty]
         public static readonly string Type = "createState";
-        [JsonProperty]
         public string Id { get; set; }
-        [JsonProperty]
         public string Desc { get; set; }
-        [JsonProperty]
         public string DefaultValue { get; set; }
     }
 }

--- a/TouchPortalApi/Models/StateCreate.cs
+++ b/TouchPortalApi/Models/StateCreate.cs
@@ -1,9 +1,17 @@
-﻿namespace TouchPortalApi.Models {
-  public class StateCreate
+﻿using Newtonsoft.Json;
+
+namespace TouchPortalApi.Models
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class StateCreate
     {
+        [JsonProperty]
         public static readonly string Type = "createState";
+        [JsonProperty]
         public string Id { get; set; }
+        [JsonProperty]
         public string Desc { get; set; }
+        [JsonProperty]
         public string DefaultValue { get; set; }
     }
 }

--- a/TouchPortalApi/Models/StateRemove.cs
+++ b/TouchPortalApi/Models/StateRemove.cs
@@ -2,12 +2,10 @@
 
 namespace TouchPortalApi.Models
 {
-    [JsonObject(MemberSerialization.OptIn)]
     public class StateRemove
     {
         [JsonProperty]
         public static readonly string Type = "removeState";
-        [JsonProperty]
         public string Id { get; set; }
     }
 }

--- a/TouchPortalApi/Models/StateRemove.cs
+++ b/TouchPortalApi/Models/StateRemove.cs
@@ -1,7 +1,13 @@
-﻿namespace TouchPortalApi.Models {
-  public class StateRemove
+﻿using Newtonsoft.Json;
+
+namespace TouchPortalApi.Models
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class StateRemove
     {
+        [JsonProperty]
         public static readonly string Type = "removeState";
+        [JsonProperty]
         public string Id { get; set; }
     }
 }

--- a/TouchPortalApi/Models/StateUpdate.cs
+++ b/TouchPortalApi/Models/StateUpdate.cs
@@ -1,7 +1,15 @@
-﻿namespace TouchPortalApi.Models {
-  public class StateUpdate {
-    public static readonly string Type = "stateUpdate";
-    public string Id { get; set; }
-    public string Value { get; set; }
-  }
+﻿using Newtonsoft.Json;
+
+namespace TouchPortalApi.Models
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class StateUpdate
+    {
+        [JsonProperty]
+        public static readonly string Type = "stateUpdate";
+        [JsonProperty]
+        public string Id { get; set; }
+        [JsonProperty]
+        public string Value { get; set; }
+    }
 }

--- a/TouchPortalApi/Models/StateUpdate.cs
+++ b/TouchPortalApi/Models/StateUpdate.cs
@@ -2,14 +2,11 @@
 
 namespace TouchPortalApi.Models
 {
-    [JsonObject(MemberSerialization.OptIn)]
     public class StateUpdate
     {
         [JsonProperty]
         public static readonly string Type = "stateUpdate";
-        [JsonProperty]
         public string Id { get; set; }
-        [JsonProperty]
         public string Value { get; set; }
     }
 }


### PR DESCRIPTION
You wouldn't be able to react with a ChoiceUpdate on a ListChangeEventHandler without instanceId as you wouldn't be able to tell instance the change happened on. And in cases when there's multiple lists on a single action that you have to respond to, you'd also need the listId.

Also would you prefer if I opened an issue to accompany future PRs?