### PR TITLE
Add support for API 3

### DIFF
--- a/TouchPortalApi/Interfaces/IMessageProcessor.cs
+++ b/TouchPortalApi/Interfaces/IMessageProcessor.cs
@@ -10,6 +10,7 @@ namespace TouchPortalApi.Interfaces {
   public delegate void ConnectEventHandler();
   public delegate void SettingEventHandler(List<Dictionary<string, dynamic>> settings);
   public delegate void BroadcastEventHandler(string eventType, string pageName);
+  public delegate void ExitHandler();
 
   public interface IMessageProcessor {
     event ActionEventHandler OnActionEvent;
@@ -19,6 +20,7 @@ namespace TouchPortalApi.Interfaces {
     event ConnectEventHandler OnConnectEventHandler;
     event SettingEventHandler OnSettingEventHandler;
     event BroadcastEventHandler OnBroadcastEventHandler;
+    event ExitHandler OnExitHandler;
 
     Task Listen();
     Task TryPairAsync();

--- a/TouchPortalApi/Interfaces/IMessageProcessor.cs
+++ b/TouchPortalApi/Interfaces/IMessageProcessor.cs
@@ -7,12 +7,14 @@ namespace TouchPortalApi.Interfaces {
   public delegate void ListChangeEventHandler(string actionId, string listId, string instanceId, string value);
   public delegate void CloseEventHandler();
   public delegate void ConnectEventHandler();
+  public delegate void SettingEventHandler(List<Dictionary<string, dynamic>> settings);
 
   public interface IMessageProcessor {
     event ActionEventHandler OnActionEvent;
     event ListChangeEventHandler OnListChangeEventHandler;
     event CloseEventHandler OnCloseEventHandler;
     event ConnectEventHandler OnConnectEventHandler;
+    event SettingEventHandler OnSettingEventHandler;
 
     Task Listen();
     Task TryPairAsync();

--- a/TouchPortalApi/Interfaces/IMessageProcessor.cs
+++ b/TouchPortalApi/Interfaces/IMessageProcessor.cs
@@ -4,6 +4,7 @@ using TouchPortalApi.Models;
 
 namespace TouchPortalApi.Interfaces {
   public delegate void ActionEventHandler(string actionId, List<ActionData> dataList);
+  public delegate void HoldActionEventHandler(string actionId, bool held, List<ActionData> dataList);
   public delegate void ListChangeEventHandler(string actionId, string listId, string instanceId, string value);
   public delegate void CloseEventHandler();
   public delegate void ConnectEventHandler();
@@ -12,6 +13,7 @@ namespace TouchPortalApi.Interfaces {
 
   public interface IMessageProcessor {
     event ActionEventHandler OnActionEvent;
+    event HoldActionEventHandler OnHoldActionEvent;
     event ListChangeEventHandler OnListChangeEventHandler;
     event CloseEventHandler OnCloseEventHandler;
     event ConnectEventHandler OnConnectEventHandler;

--- a/TouchPortalApi/Interfaces/IMessageProcessor.cs
+++ b/TouchPortalApi/Interfaces/IMessageProcessor.cs
@@ -8,6 +8,7 @@ namespace TouchPortalApi.Interfaces {
   public delegate void CloseEventHandler();
   public delegate void ConnectEventHandler();
   public delegate void SettingEventHandler(List<Dictionary<string, dynamic>> settings);
+  public delegate void BroadcastEventHandler(string eventType, string pageName);
 
   public interface IMessageProcessor {
     event ActionEventHandler OnActionEvent;
@@ -15,6 +16,7 @@ namespace TouchPortalApi.Interfaces {
     event CloseEventHandler OnCloseEventHandler;
     event ConnectEventHandler OnConnectEventHandler;
     event SettingEventHandler OnSettingEventHandler;
+    event BroadcastEventHandler OnBroadcastEventHandler;
 
     Task Listen();
     Task TryPairAsync();

--- a/TouchPortalApi/MessageProcessor.cs
+++ b/TouchPortalApi/MessageProcessor.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using TouchPortalApi.Configuration;
@@ -32,6 +33,7 @@ namespace TouchPortalApi {
     public event ConnectEventHandler OnConnectEventHandler;
     public event SettingEventHandler OnSettingEventHandler;
     public event BroadcastEventHandler OnBroadcastEventHandler;
+    public event ExitHandler OnExitHandler;
 
     #endregion
 
@@ -65,6 +67,9 @@ namespace TouchPortalApi {
       while (!_cancellationToken.IsCancellationRequested) {
         try {
           await _tPClient.ProcessPipes();
+        } catch (SocketException) {
+          OnExitHandler?.Invoke();
+          return;
         } catch (Exception ex) {
           Console.WriteLine(ex);
         }

--- a/TouchPortalApi/MessageProcessor.cs
+++ b/TouchPortalApi/MessageProcessor.cs
@@ -26,6 +26,7 @@ namespace TouchPortalApi {
     #region Event Handlers
 
     public event ActionEventHandler OnActionEvent;
+    public event HoldActionEventHandler OnHoldActionEvent;
     public event ListChangeEventHandler OnListChangeEventHandler;
     public event CloseEventHandler OnCloseEventHandler;
     public event ConnectEventHandler OnConnectEventHandler;
@@ -115,6 +116,12 @@ namespace TouchPortalApi {
           case "broadcast":
             HandleBroadcastEvent(JsonConvert.DeserializeObject<TPBroadcast>(result));
             break;
+          case "up":
+            HandleHoldActionEvent(JsonConvert.DeserializeObject<TPAction>(result), false);
+            break;
+          case "down":
+            HandleHoldActionEvent(JsonConvert.DeserializeObject<TPAction>(result), true);
+            break;
           default:
             Console.WriteLine($"No operation defined for: {responseModel.Type.ToLower().Trim()}");
             break;
@@ -159,6 +166,14 @@ namespace TouchPortalApi {
     /// <param name="action">The action being triggered</param>
     private void HandleActionEvent(TPAction action) {
       OnActionEvent?.Invoke(action.ActionId, action.Data);
+    }
+
+    /// <summary>
+    /// Handle an on hold event
+    /// </summary>
+    /// <param name="action">The action being triggered</param>
+    private void HandleHoldActionEvent(TPAction action, bool held) {
+      OnHoldActionEvent?.Invoke(action.ActionId, held, action.Data);
     }
 
     /// <summary>

--- a/TouchPortalApi/MessageProcessor.cs
+++ b/TouchPortalApi/MessageProcessor.cs
@@ -147,7 +147,7 @@ namespace TouchPortalApi {
     /// <summary>
     /// Handle setting event
     /// </summary>
-    /// <param name="response">The TP Pair Response</param>
+    /// <param name="setting">The new settings</param>
     private void HandleSettingEvent(TPSettingChange setting) {
       OnSettingEventHandler?.Invoke(setting.Values);
     }
@@ -155,7 +155,7 @@ namespace TouchPortalApi {
     /// <summary>
     /// Handle broadcast event
     /// </summary>
-    /// <param name="response">The TP Pair Response</param>
+    /// <param name="broadcast">The broadcast event</param>
     private void HandleBroadcastEvent(TPBroadcast broadcast) {
       OnBroadcastEventHandler?.Invoke(broadcast.Event, broadcast.PageName);
     }
@@ -172,6 +172,7 @@ namespace TouchPortalApi {
     /// Handle an on hold event
     /// </summary>
     /// <param name="action">The action being triggered</param>
+    /// <param name="held">True if held, false when released</param>
     private void HandleHoldActionEvent(TPAction action, bool held) {
       OnHoldActionEvent?.Invoke(action.ActionId, held, action.Data);
     }

--- a/TouchPortalApi/MessageProcessor.cs
+++ b/TouchPortalApi/MessageProcessor.cs
@@ -30,6 +30,7 @@ namespace TouchPortalApi {
     public event CloseEventHandler OnCloseEventHandler;
     public event ConnectEventHandler OnConnectEventHandler;
     public event SettingEventHandler OnSettingEventHandler;
+    public event BroadcastEventHandler OnBroadcastEventHandler;
 
     #endregion
 
@@ -95,8 +96,9 @@ namespace TouchPortalApi {
           case "info":
             PairResponse pairResponse = JsonConvert.DeserializeObject<PairResponse>(result);
             HandlePairEvent(pairResponse);
-            if(pairResponse.Settings != null)
-              HandleSettingEvent(pairResponse.Settings);
+            if(pairResponse.Settings != null) {
+               HandleSettingEvent(new TPSettingChange { Values = pairResponse.Settings });
+            }
             break;
           case "action":
             HandleActionEvent(JsonConvert.DeserializeObject<TPAction>(result));
@@ -108,7 +110,10 @@ namespace TouchPortalApi {
             HandleCloseEvent();
             break;
           case "settings":
-            HandleSettingEvent(JsonConvert.DeserializeObject<TPSettingChange>(result).Values);
+            HandleSettingEvent(JsonConvert.DeserializeObject<TPSettingChange>(result));
+            break;
+          case "broadcast":
+            HandleBroadcastEvent(JsonConvert.DeserializeObject<TPBroadcast>(result));
             break;
           default:
             Console.WriteLine($"No operation defined for: {responseModel.Type.ToLower().Trim()}");
@@ -133,12 +138,19 @@ namespace TouchPortalApi {
     }
 
     /// <summary>
-    /// Handle connect event
+    /// Handle setting event
     /// </summary>
     /// <param name="response">The TP Pair Response</param>
-    private void HandleSettingEvent(List<Dictionary<string, dynamic>> settings) {
-      // Good pairing message returned
-      OnSettingEventHandler?.Invoke(settings);
+    private void HandleSettingEvent(TPSettingChange setting) {
+      OnSettingEventHandler?.Invoke(setting.Values);
+    }
+
+    /// <summary>
+    /// Handle broadcast event
+    /// </summary>
+    /// <param name="response">The TP Pair Response</param>
+    private void HandleBroadcastEvent(TPBroadcast broadcast) {
+      OnBroadcastEventHandler?.Invoke(broadcast.Event, broadcast.PageName);
     }
 
     /// <summary>

--- a/TouchPortalApi/Models/Initialization/PairResponse.cs
+++ b/TouchPortalApi/Models/Initialization/PairResponse.cs
@@ -1,4 +1,5 @@
-﻿using TouchPortalApi.Models.TouchPortal.Responses;
+﻿using System.Collections.Generic;
+using TouchPortalApi.Models.TouchPortal.Responses;
 
 namespace TouchPortalApi.Models.Initialization {
   internal class PairResponse : TPResponseBase {
@@ -6,5 +7,7 @@ namespace TouchPortalApi.Models.Initialization {
     public string TPVersionString { get; set; }
     public string TPVersionCode { get; set; }
     public string PluginVersion { get; set; }
+
+    public List<Dictionary<string, dynamic>> Settings { get; set; }
   }
 }

--- a/TouchPortalApi/Models/StateCreate.cs
+++ b/TouchPortalApi/Models/StateCreate.cs
@@ -9,5 +9,6 @@ namespace TouchPortalApi.Models
         public string Id { get; set; }
         public string Desc { get; set; }
         public string DefaultValue { get; set; }
+        public string ParentGroup { get; set; }
     }
 }

--- a/TouchPortalApi/Models/TouchPortal/Responses/TPBroadcast.cs
+++ b/TouchPortalApi/Models/TouchPortal/Responses/TPBroadcast.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace TouchPortalApi.Models.TouchPortal.Responses {
+  /// <summary>
+  /// Class for the TP Response type of broadcast
+  /// </summary>
+  internal class TPBroadcast : TPShared {
+    /// <summary>
+    /// Event type
+    /// </summary>
+    public string Event { get; set; }
+
+    /// <summary>
+    /// Name of the page that was switched to
+    /// </summary>
+    public string PageName { get; set; }
+  }
+}

--- a/TouchPortalApi/Models/TouchPortal/Responses/TPSettingChange.cs
+++ b/TouchPortalApi/Models/TouchPortal/Responses/TPSettingChange.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace TouchPortalApi.Models.TouchPortal.Responses {
+  /// <summary>
+  /// Class for the TP Response type of List Change
+  /// </summary>
+  /// 
+  internal class TPSettingChange : TPShared {
+    /// <summary>
+    /// New values
+    /// </summary>
+    public List<Dictionary<string, dynamic>> Values { get; set; }
+  }
+}

--- a/TouchPortalApi/Models/TouchPortal/Responses/TPSettingChange.cs
+++ b/TouchPortalApi/Models/TouchPortal/Responses/TPSettingChange.cs
@@ -2,7 +2,7 @@
 
 namespace TouchPortalApi.Models.TouchPortal.Responses {
   /// <summary>
-  /// Class for the TP Response type of List Change
+  /// Class for the TP Response type of Setting Change
   /// </summary>
   /// 
   internal class TPSettingChange : TPShared {

--- a/TouchPortalApi/TPClient.cs
+++ b/TouchPortalApi/TPClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.IO.Pipelines;
 using System.Net;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -85,6 +86,8 @@ namespace TouchPortalApi {
       Task reading = ReadPipeAsync(pipe.Reader);
 
       await Task.WhenAll(reading, writing).ConfigureAwait(false);
+      if(!_tpsocket.Connected)
+        throw new SocketException();
     }
 
     /// <summary>

--- a/TouchPortalApi/TPClient.cs
+++ b/TouchPortalApi/TPClient.cs
@@ -63,7 +63,7 @@ namespace TouchPortalApi {
     /// <param name="cancellationToken">The cancellation token</param>
     public async Task SendAsync(object model, CancellationToken cancellationToken = default) {
       string request = PrepareMessage(model);
-      var bytesSent = Encoding.ASCII.GetBytes(request);
+      var bytesSent = Encoding.UTF8.GetBytes(request);
 
       await _tpsocket.SendAsync(bytesSent, cancellationToken);
     }

--- a/TouchPortalApi/TouchPortalApi.csproj
+++ b/TouchPortalApi/TouchPortalApi.csproj
@@ -14,6 +14,7 @@
     <Copyright>2020</Copyright>
     <NeutralLanguage></NeutralLanguage>
     <FileVersion>0.3.3.0</FileVersion>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TouchPortalApi/TouchPortalApi.csproj
+++ b/TouchPortalApi/TouchPortalApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyVersion>0.3.3.0</AssemblyVersion>
     <Version>0.3.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
I'm not sure if this is how you intended to handle this but I've set things up such that OnSettingsEventHandler() fires immediately after OnConnectEventHandler() when settings are available along with the info payload. This makes sure that plugins will be able to handle settings changes from the same handler regardless of whether the settings came from the info or settings payload from Touch Portal. In any case, here is PR for your review.

One thing I am considering changing is how the settings are passed onto OnSettingsEventHandler(). It's currently a List<Dictionary<string, dynamic>> as that is how the settings are passed by Touch Portal. I retained that for compatibility with the payload in case the way the data being sent changes but not the schema, but it makes more sense to combine everything into a single dictionary the way Touch Portal is currently sending the settings.