### PR TITLE
Add exit handler which fires when Touch Portal exits with the plugin …

### DIFF
--- a/TouchPortalApi/Interfaces/IMessageProcessor.cs
+++ b/TouchPortalApi/Interfaces/IMessageProcessor.cs
@@ -7,12 +7,14 @@ namespace TouchPortalApi.Interfaces {
   public delegate void ListChangeEventHandler(string actionId, string listId, string instanceId, string value);
   public delegate void CloseEventHandler();
   public delegate void ConnectEventHandler();
+  public delegate void ExitHandler();
 
   public interface IMessageProcessor {
     event ActionEventHandler OnActionEvent;
     event ListChangeEventHandler OnListChangeEventHandler;
     event CloseEventHandler OnCloseEventHandler;
     event ConnectEventHandler OnConnectEventHandler;
+    event ExitHandler OnExitHandler;
 
     Task Listen();
     Task TryPairAsync();

--- a/TouchPortalApi/MessageProcessor.cs
+++ b/TouchPortalApi/MessageProcessor.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Buffers;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using TouchPortalApi.Configuration;
@@ -28,6 +29,7 @@ namespace TouchPortalApi {
     public event ListChangeEventHandler OnListChangeEventHandler;
     public event CloseEventHandler OnCloseEventHandler;
     public event ConnectEventHandler OnConnectEventHandler;
+    public event ExitHandler OnExitHandler;
 
     #endregion
 
@@ -61,6 +63,9 @@ namespace TouchPortalApi {
       while (!_cancellationToken.IsCancellationRequested) {
         try {
           await _tPClient.ProcessPipes();
+        } catch (SocketException) {
+          OnExitHandler?.Invoke();
+          return;
         } catch (Exception ex) {
           Console.WriteLine(ex);
         }

--- a/TouchPortalApi/TPClient.cs
+++ b/TouchPortalApi/TPClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.IO.Pipelines;
 using System.Net;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -85,6 +86,8 @@ namespace TouchPortalApi {
       Task reading = ReadPipeAsync(pipe.Reader);
 
       await Task.WhenAll(reading, writing).ConfigureAwait(false);
+      if(!_tpsocket.Connected)
+        throw new SocketException();
     }
 
     /// <summary>


### PR DESCRIPTION
This adds an exit handler which fires when Touch Portal exits with the plugin still running so that the plugin can quit gracefully.

This fixes an issue where the main plugin loop is not able to detect that Touch Portal has exited. It still requires the exit handler to terminate the plugin process, but otherwise, I haven't found a way to detect that the socket to Touch Portal is already closed.

I've used a separate PR for this so that it can be reviewed separately from the PR for API 3 additions. Hopefully, this doesn't cause any merge issues if/when both PRs gets merged.